### PR TITLE
typo in matlab batch call

### DIFF
--- a/docs/hpc/howto/matlab.md
+++ b/docs/hpc/howto/matlab.md
@@ -52,7 +52,7 @@ In order to run MATLAB in jobs, the MATLAB environment module needs to be loaded
 #$ -cwd          # run job in the current working directory
 
 module load matlab
-matlab -singleCompThread -batch my_script.m
+matlab -singleCompThread -batch my_script
 ```
 
 The `-batch` option tells MATLAB to run the `my_script.m` script in batch mode, in contrast to interactive mode.  The `-singleCompThread` option tells MATLAB to run in sequential mode; this prevents your job for overusing the compute nodes by mistake.


### PR DESCRIPTION
The command doesn't work as it is written: the script should be called by name and not file name, i.e.:
```matlab
matlab -singleCompThread -batch my_script 
```
notice the `my_script` and not `my_script.m`  
 [source](https://www.mathworks.com/matlabcentral/answers/553885-getting-the-error-unable-to-resolve-the-name-filename-m-while-trying-to-run-a-script#answer_456388)